### PR TITLE
[11] Add button to copy gamer details

### DIFF
--- a/src/main/java/seedu/blockbook/ui/GamerCard.java
+++ b/src/main/java/seedu/blockbook/ui/GamerCard.java
@@ -4,6 +4,8 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.input.Clipboard;
+import javafx.scene.input.ClipboardContent;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.blockbook.logic.Messages;
@@ -86,5 +88,16 @@ public class GamerCard extends UiPart<Region> {
         favouriteIcon.setImage(isFavourite ? FAVOURITE_ICON : null);
         favouriteIcon.setVisible(isFavourite);
         favouriteIcon.setManaged(isFavourite);
+    }
+
+    /**
+     * Copies the gamer's details to the clipboard.
+     */
+    @FXML
+    private void copyDetails() {
+        final Clipboard clipboard = Clipboard.getSystemClipboard();
+        final ClipboardContent details = new ClipboardContent();
+        details.putString(Messages.format(gamer));
+        clipboard.setContent(details);
     }
 }

--- a/src/main/resources/view/GamerListCard.fxml
+++ b/src/main/resources/view/GamerListCard.fxml
@@ -1,43 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <VBox alignment="CENTER_LEFT" minHeight="100" spacing="8" styleClass="gamer-card-body" HBox.hgrow="ALWAYS">
     <padding>
-      <Insets top="8" right="10" bottom="8" left="12" />
+      <Insets bottom="8" left="12" right="10" top="8" />
     </padding>
 
-    <HBox spacing="8" alignment="CENTER_LEFT">
+    <HBox alignment="CENTER_LEFT" spacing="8">
       <Label fx:id="id" styleClass="cell_index_label">
         <minWidth>
           <!-- Ensures that the label text is never truncated -->
           <Region fx:constant="USE_PREF_SIZE" />
         </minWidth>
       </Label>
-      <Label fx:id="name" text="name" styleClass="cell_name_label" />
+      <Label fx:id="name" styleClass="cell_name_label" text="name" />
       <ImageView fx:id="favouriteIcon" fitHeight="20.0" fitWidth="20.0" preserveRatio="true" smooth="false" />
       <Region HBox.hgrow="ALWAYS" />
+         <Button mnemonicParsing="false" text="Copy" onAction="#copyDetails"/>
     </HBox>
 
-    <Label fx:id="gamerTag" text="@gamerTag" styleClass="cell_tag_label" />
+    <Label fx:id="gamerTag" styleClass="cell_tag_label" text="@gamerTag" />
 
     <GridPane hgap="10" vgap="4">
       <columnConstraints>
         <ColumnConstraints minWidth="70" prefWidth="70" />
         <ColumnConstraints hgrow="ALWAYS" minWidth="10" prefWidth="240" />
       </columnConstraints>
-      <Label text="Server" styleClass="card_meta_key" GridPane.columnIndex="0" GridPane.rowIndex="0" />
-      <Label fx:id="server" text="$server" styleClass="card_meta_value" GridPane.columnIndex="1" GridPane.rowIndex="0" />
-      <Label text="Region" styleClass="card_meta_key" GridPane.columnIndex="0" GridPane.rowIndex="1" />
-      <Label fx:id="region" text="$region" styleClass="card_meta_value" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+      <Label styleClass="card_meta_key" text="Server" GridPane.columnIndex="0" GridPane.rowIndex="0" />
+      <Label fx:id="server" styleClass="card_meta_value" text="$server" GridPane.columnIndex="1" GridPane.rowIndex="0" />
+      <Label styleClass="card_meta_key" text="Region" GridPane.columnIndex="0" GridPane.rowIndex="1" />
+      <Label fx:id="region" styleClass="card_meta_value" text="$region" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+         <rowConstraints>
+            <RowConstraints />
+            <RowConstraints />
+         </rowConstraints>
     </GridPane>
   </VBox>
 </HBox>


### PR DESCRIPTION
## What's changed

Added a button to the upper right of the gamer card that copies the gamer's details to the user's clipboard.


## To do next week
Modify button to display a [copy to clipboard](https://www.google.com/search?sca_esv=3087728c2f704245&rlz=1C1GCEA_enSG1112SG1112&sxsrf=ANbL-n50Ls8kuFuFBRnpz6hZTWhsEyCAMQ:1774504958158&udm=2&fbs=ADc_l-aN0CWEZBOHjofHoaMMDiKpaEWjvZ2Py1XXV8d8KvlI3o6iwGk6Iv1tRbZIBNIVs-5-bUj3iBl-UxHsANYwOkWWIHyK1NRBVtxaVLlI368r1pVkTF8dikqaIUDHe6ZJqgrtGKFguRwxeugWaDc6vA-ZCHR8WPXxHUpvaC4AqgGAe29vMyS3iHy8YkqMAmfHYvNDaUPlZQ6fkk7aiPg8XCKDo9WRwA&q=copy+to+clipboard+icon&sa=X&ved=2ahUKEwjmnLuN8ryTAxXAoGMGHQf3OCIQtKgLegQIEBAB&biw=1646&bih=804&dpr=1.75) icon instead of just "Copy".
Provide user feedback via the command result window to show that details have been copied.

Closes #119.