### PR TITLE
[21] Add multiple deletion sequence diagrams

### DIFF
--- a/docs/diagrams/DeleteMultipleSequenceDiagram.puml
+++ b/docs/diagrams/DeleteMultipleSequenceDiagram.puml
@@ -1,0 +1,77 @@
+﻿@startuml
+!include style.puml
+skinparam ArrowFontStyle plain
+
+box Logic LOGIC_COLOR_T1
+participant ":LogicManager" as LogicManager LOGIC_COLOR
+participant ":BlockBookParser" as BlockBookParser LOGIC_COLOR
+participant ":DeleteCommandParser" as DeleteCommandParser LOGIC_COLOR
+participant "d:DeleteCommand" as DeleteCommand LOGIC_COLOR
+participant "r:CommandResult" as CommandResult LOGIC_COLOR
+end box
+
+box Model MODEL_COLOR_T1
+participant "m:Model" as Model MODEL_COLOR
+end box
+
+[-> LogicManager : execute("delete 1 2")
+activate LogicManager
+
+LogicManager -> BlockBookParser : parseCommand("delete 1 2")
+activate BlockBookParser
+
+create DeleteCommandParser
+BlockBookParser -> DeleteCommandParser
+activate DeleteCommandParser
+
+DeleteCommandParser --> BlockBookParser
+deactivate DeleteCommandParser
+
+BlockBookParser -> DeleteCommandParser : parse("1 2")
+activate DeleteCommandParser
+
+create DeleteCommand
+DeleteCommandParser -> DeleteCommand
+activate DeleteCommand
+
+DeleteCommand --> DeleteCommandParser :
+deactivate DeleteCommand
+
+DeleteCommandParser --> BlockBookParser : d
+deactivate DeleteCommandParser
+'Hidden arrow to position the destroy marker below the end of the activation bar.
+DeleteCommandParser -[hidden]-> BlockBookParser
+destroy DeleteCommandParser
+
+BlockBookParser --> LogicManager : d
+deactivate BlockBookParser
+
+LogicManager -> DeleteCommand : execute(m)
+activate DeleteCommand
+
+DeleteCommand -> Model : deleteGamer(1)
+activate Model
+
+Model --> DeleteCommand
+deactivate Model
+
+DeleteCommand -> Model : deleteGamer(2)
+activate Model
+
+Model --> DeleteCommand
+deactivate Model
+
+create CommandResult
+DeleteCommand -> CommandResult
+activate CommandResult
+
+CommandResult --> DeleteCommand
+deactivate CommandResult
+
+DeleteCommand --> LogicManager : r
+deactivate DeleteCommand
+
+[<--LogicManager
+deactivate LogicManager
+@enduml
+


### PR DESCRIPTION
Adds a new diagram for the updated implementation of `DeleteCommand` that allows the deletion of multiple gamers with 1 command. As part of #150.