### PR TITLE
[1.1] Fix `GAMERTAG` attribute ambiguity by letter casing

### DIFF
--- a/src/main/java/seedu/blockbook/model/gamer/GamerTag.java
+++ b/src/main/java/seedu/blockbook/model/gamer/GamerTag.java
@@ -55,13 +55,17 @@ public class GamerTag {
             return false;
         }
 
-        GamerTag otherName = (GamerTag) other;
-        return fullGamerTag.equals(otherName.fullGamerTag);
+        GamerTag otherGamerTag = (GamerTag) other;
+        return fullGamerTag.equalsIgnoreCase(otherGamerTag.fullGamerTag);
     }
 
+    /**
+     * Returns a case-insensitive hash code for this gamertag.
+     * Gamertags that differ only by letter casing will have the same hash code.
+     */
     @Override
     public int hashCode() {
-        return fullGamerTag.hashCode();
+        return fullGamerTag.toLowerCase().hashCode();
     }
 
 }


### PR DESCRIPTION
**Summary**
This PR updates gamertag identity handling so duplicate detection is **case-insensitive** while preserving the user’s original input casing for display.

**Changes made**
- Updated GamerTag equality logic so gamertags differing only by letter casing are treated as equal
  - for example, `BaNaNa` and `banana` are now considered duplicates
- Updated `GamerTag.hashCode()` to be consistent with the new case-insensitive equality behavior
- Preserved the original input casing for display and serialization
  - if the user enters `BaNaNa`, it is still shown as `BaNaNa`

Closes #160 