### PR TITLE
[1.5] Change message usage that contains `SEA` as valid region parameter in `ADD` command

### DIFF
--- a/src/main/java/seedu/blockbook/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/blockbook/logic/commands/AddCommand.java
@@ -28,7 +28,7 @@ public class AddCommand extends Command {
             + "Example: add gamertag/ilovesteve name/Herobrine "
             + "phone/99999 email/brine@gmail.com "
             + "group/DestroySteve server/127.0.0.1:8080 favourite/fav "
-            + "country/Singapore region/SEA note/I hate steve";
+            + "country/Singapore region/ASIA note/I hate steve";
 
     public static final String MESSAGE_SUCCESS = "Contact added: %1$s";
     public static final String MESSAGE_DUPLICATE_GAMERTAG = "This gamertag is already used by someone in BlockBook.";


### PR DESCRIPTION
**Summary**
This PR updates the `AddCommand` usage example so it uses a region value that is actually supported by the current `Region` enum and validation logic.

**Changes made**
- Changed the `AddCommand.MESSAGE_USAGE` example from `region/SEA` to `region/ASIA`

Closes #164