### PR TITLE
[1.6] `NOTE` attribute ambiguity by specification

### DIFF
--- a/src/main/java/seedu/blockbook/model/gamer/Note.java
+++ b/src/main/java/seedu/blockbook/model/gamer/Note.java
@@ -11,9 +11,9 @@ public class Note {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Notes should only contain, letters, numbers and underscore, "
-                    + "and be at most 30 characters.";
-    public static final String VALIDATION_REGEX = "^[a-zA-Z0-9_ '\\\\-]{1,50}$";
+            "Notes should only contain letters, numbers, spaces, underscores (_), hyphens (-), "
+                    + "and apostrophes ('), and be at most 50 characters long.";
+    public static final String VALIDATION_REGEX = "^[a-zA-Z0-9_ '\\-]{1,50}$";
     public final String fullNote;
 
     /**


### PR DESCRIPTION
**Summary**
This PR updates the note attribute documentation and validation message so they match the actual allowed character set and length constraints.

**Changes made**
- Updated `Note.MESSAGE_CONSTRAINTS` to reflect the intended note specification
  - `"Notes should only contain letters, numbers, spaces, underscores (_), hyphens (-), and apostrophes ('), and be at most 50 characters long."`
- Clarified that notes may contain:
  - letters
  - numbers
  - spaces
  - underscores (`_`)
  - hyphens (`-`)
  - apostrophes (`'`)
- Updated the note constraint wording to state the 50-character maximum clearly
- Aligned the note regex/message pair so the user-facing error matches the implemented validation behaviour

**Example Usage**
Apostrophes `' `
- `"John's alt account"`
- `"doesn't use mic"`

Hyphens `-` (used for descriptions)
- `"late-night player"`
- `"fast-paced teammate"`

Underscores `_`
- `"discord_user: neko_chan"`
- `"instagramID: neko_rin"`

Closes #165 
Closes #161 