### PR TITLE
[1.10] Change message usage that contains SEA as valid region parameter in edit command

### DIFF
--- a/src/main/java/seedu/blockbook/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/blockbook/logic/commands/EditCommand.java
@@ -38,7 +38,7 @@ public class EditCommand extends Command {
             + "Format: edit INDEX [gamertag/GAMERTAG] [name/NAME] [phone/PHONE] [email/EMAIL] "
             + "[group/GROUP] [server/SERVER] [favourite/FAVOURITE] [country/COUNTRY] [region/REGION] [note/NOTE]\n"
             + "Example: edit 1 name/Herobrine gamertag/ilovesteve phone/99999 "
-            + "email/brine@gmail.com group/DestroySteve favourite/fav country/Singapore region/SEA "
+            + "email/brine@gmail.com group/DestroySteve favourite/fav country/Singapore region/ASIA "
             + "note/I hate steve";
 
     public static final String MESSAGE_EDIT_GAMER_SUCCESS = "Contact edited: %1$s";


### PR DESCRIPTION
Changed the EditCommand.MESSAGE_USAGE example from region/SEA to region/ASIA

Closes #169