### PR TITLE
[1.16] Fix edit and test for out of range values error

### DIFF
--- a/src/main/java/seedu/blockbook/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/blockbook/logic/parser/EditCommandParser.java
@@ -14,6 +14,7 @@ import static seedu.blockbook.logic.parser.CliSyntax.PREFIX_REGION;
 import static seedu.blockbook.logic.parser.CliSyntax.PREFIX_SERVER;
 
 import seedu.blockbook.commons.core.index.Index;
+import seedu.blockbook.logic.Messages;
 import seedu.blockbook.logic.commands.EditCommand;
 import seedu.blockbook.logic.commands.EditCommand.EditGamerDescriptor;
 import seedu.blockbook.logic.parser.exceptions.ParseException;
@@ -47,6 +48,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
+            String trimmedPreamble = argMultimap.getPreamble().trim();
+            if (trimmedPreamble.matches("-?\\d+")) {
+                throw new ParseException(Messages.MESSAGE_INDEX_OUT_OF_RANGE, pe);
+            }
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
 

--- a/src/test/java/seedu/blockbook/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/blockbook/logic/parser/EditCommandParserTest.java
@@ -44,26 +44,35 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_missingParts_failure() {
+        // EP: missing index
         assertParseFailure(parser, VALID_NAME_BOB, MESSAGE_INVALID_FORMAT);
+        // EP: missing fields
         assertParseFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED);
+        // EP: empty input
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
     }
 
     @Test
     public void parse_invalidPreamble_failure() {
-        assertParseFailure(parser, "-5" + NAME_DESC_BOB, MESSAGE_INVALID_FORMAT);
-        assertParseFailure(parser, "0" + NAME_DESC_BOB, MESSAGE_INVALID_FORMAT);
+        // EP: invalid numeric index (negative)
+        assertParseFailure(parser, "-5" + NAME_DESC_BOB, Messages.MESSAGE_INDEX_OUT_OF_RANGE);
+        // EP: invalid numeric index (zero)
+        assertParseFailure(parser, "0" + NAME_DESC_BOB, Messages.MESSAGE_INDEX_OUT_OF_RANGE);
+        // EP: preamble contains extra tokens
         assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+        // EP: non-numeric preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB, MESSAGE_INVALID_FORMAT);
     }
 
     @Test
     public void parse_invalidValue_failure() {
+        // EP: invalid field value
         assertParseFailure(parser, "1" + INVALID_NAME_DESC, seedu.blockbook.model.gamer.Name.MESSAGE_CONSTRAINTS);
     }
 
     @Test
     public void parse_allFieldsSpecified_success() {
+        // EP: all valid fields present
         String userInput = INDEX_SECOND_GAMER.getOneBased()
                 + GAMERTAG_DESC_BOB
                 + NAME_DESC_BOB
@@ -95,6 +104,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_repeatedValue_failure() {
+        // EP: duplicate prefix in input
         String userInput = INDEX_FIRST_GAMER.getOneBased() + NAME_DESC_BOB + NAME_DESC_BOB;
         assertParseFailure(parser, userInput,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));


### PR DESCRIPTION
Updated EditCommandParser to return “Index out of range” for numeric invalid indexes (0/negative).
Synced tests with updated messaging/formatting.

Closes #180