### PR TITLE
Draft UserGuide.md on `Add` command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -86,8 +86,9 @@ Format: `add gamertag/GAMERTAG [name/NAME] [phone/PHONE] [email/EMAIL] [group/GR
 
 **Tip:** Only `gamertag/` is required. All other fields are optional.
 </box>
-- `favourite/` accepts `fav` or `unfav`
-- `region/` accepts `NA`, `SA`, `EU`, `AFRICA`, `ASIA`, `OCEANIA` or `ME`
+- `email/`, must be a valid email in the format `local-part@domain`.
+- `favourite/` accepts `fav` or `unfav`.
+- `region/` accepts `NA`, `SA`, `EU`, `AFRICA`, `ASIA`, `OCEANIA` or `ME`.
 
 Examples:
 * `add gamertag/ilovesteve name/Herobrine phone/99999 email/brine@gmail.com group/DestroySteve server/127.0.0.1:8080 favourite/fav country/Singapore region/ASIA note/I hate steve`


### PR DESCRIPTION
**Summary**
This PR updates the `ADD` command documentation to better reflect the current implementation and accepted input values.

**Changes made**
- Clarified that only `gamertag/` is required for the add command
- Stated that all other add fields are optional
- Added documentation that:
  - `email/`, must be a valid email in the format `local-part@domain`
  - `favourite/` accepts `fav` or `unfav`
  - region/ accepts `NA`, `SA`, `EU`, `AFRICA`, `ASIA`, `OCEANIA` or `ME`
- Updated add examples to use valid region values and current argument conventions

**Remaining changes will be finalised once bugs have been fixed**

Closes #213 