### PR TITLE
[1.26] Restrict `find` command to formats 1 and 2 only

### DIFF
--- a/src/main/java/seedu/blockbook/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/blockbook/logic/parser/FindCommandParser.java
@@ -64,8 +64,14 @@ public class FindCommandParser implements Parser<FindCommand> {
                         || argMultimap.getValue(PREFIX_REGION).isPresent()
                         || argMultimap.getValue(PREFIX_NOTE).isPresent();
 
+        String preamble = argMultimap.getPreamble().trim();
+        // Prevent mixed formats
+        if (hasAnyPrefixedArguments && !preamble.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+
         if (!hasAnyPrefixedArguments) {
-            String preamble = argMultimap.getPreamble().trim();
             if (preamble.length() > 50) {
                 throw new ParseException("Global search KEYWORD input cannot exceed 50 characters.");
             }
@@ -168,4 +174,3 @@ public class FindCommandParser implements Parser<FindCommand> {
     }
 
 }
-

--- a/src/test/java/seedu/blockbook/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/blockbook/logic/parser/FindCommandParserTest.java
@@ -159,6 +159,15 @@ public class FindCommandParserTest {
     }
 
     /**
+     * Verifies that mixing global and specific search formats is rejected.
+     */
+    @Test
+    public void parse_mixedGlobalAndSpecific_throwsParseException() {
+        assertParseFailure(parser, "herobrine " + PREFIX_NAME + "Steve",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    /**
      * Verifies that valid specific search format returns FindCommand with SpecificAttributesMatchPredicate.
      */
     @Test
@@ -178,5 +187,4 @@ public class FindCommandParserTest {
     }
 
 }
-
 


### PR DESCRIPTION
Closes #190 