### PR TITLE
[1.14] Fix blinking gamer card issue in GUI

### DIFF
--- a/src/main/java/seedu/blockbook/ui/GamerListPanel.java
+++ b/src/main/java/seedu/blockbook/ui/GamerListPanel.java
@@ -33,19 +33,25 @@ public class GamerListPanel extends UiPart<Region> {
      * Custom {@code ListCell} that displays the graphics of a {@code Gamer} using a {@code GamerCard}.
      */
     class GamerListViewCell extends ListCell<Gamer> {
+        private GamerCard card;
+
         @Override
         protected void updateItem(Gamer gamer, boolean empty) {
             super.updateItem(gamer, empty);
 
             if (empty || gamer == null) {
+                card = null;
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new GamerCard(gamer, getIndex() + 1).getRoot());
+                // Update card only if there is changes to the gamer.
+                if (card == null || card.gamer != gamer) {
+                    card = new GamerCard(gamer, getIndex() + 1);
+                }
+                setGraphic(card.getRoot());
             }
         }
     }
 
 }
-
 


### PR DESCRIPTION
Closes #178. This is an attempt tried on MacOS, would need Windows testing.

The suspect here could have been the the way the UI was updating. It was being updated everytime there was an action on the UI, thus it had to render multiple times. This PR solves it by caching the gamer card, and only setting when there is a change to the card.