### PR TITLE
[PE-D][Tester-D] Update BB to BlockBook and extra documentation

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -299,7 +299,7 @@ As these represent the expected behaviour of the final iteration, some use cases
 
 1.  User chooses to add a new gamer contact.
 2.  User provides the required gamertag and any optional fields.
-3.  BB saves the new gamer contact and displays a success message with the updated contact list.
+3.  BlockBook saves the new gamer contact and displays a success message with the updated contact list.
 
 Use case ends.
 
@@ -307,19 +307,19 @@ Use case ends.
 
 2a. The required gamertag field is missing.
 
-- 2a1. BB displays an error message showing the correct command format.
+- 2a1. BlockBook displays an error message showing the correct command format.
 - 2a2. User re-enters the add command with corrected input.
 - Use case resumes at step 1.
 
 2b. One or more specified fields contain invalid values.
 
-- 2b1. BB displays an error message indicating that the input is invalid.
+- 2b1. BlockBook displays an error message indicating that the input is invalid.
 - 2b2. User re-enters the add command with corrected input.
 - Use case resumes at step 1.
 
 2c. A contact with the same gamertag already exists.
 
-- 2c1. BB displays an error message indicating that the gamertag is already in use.
+- 2c1. BlockBook displays an error message indicating that the gamertag is already in use.
 - 2c2. User re-enters the add command with a different gamertag.
 - Use case resumes at step 1.
 
@@ -328,7 +328,7 @@ Use case ends.
 **MSS**
 
 1. User chooses to view all saved contacts.
-2. BB displays a list of all contacts with their details in the default order.
+2. BlockBook displays a list of all contacts with their details in the default order.
 
 Use case ends.
 
@@ -336,7 +336,7 @@ Use case ends.
 
 2a. The contact list is empty.
 
-- 2a1. BB informs the user that no contacts are currently stored.
+- 2a1. BlockBook informs the user that no contacts are currently stored.
 - Use case ends.
 
 #### UC03 - Favourite/Unfavourite a Contact
@@ -344,7 +344,7 @@ Use case ends.
 **MSS**
 
 1. User requests to favourite/unfavourite a contact by index.
-2. BB updates favourite status and displays confirmation.
+2. BlockBook updates favourite status and displays confirmation.
 
 Use case ends.
 
@@ -352,22 +352,22 @@ Use case ends.
 
 1a. User enters an invalid index (non-numeric).
 
-- 1a1. BB displays an error message.
+- 1a1. BlockBook displays an error message.
 - Use case ends.
 
 1b. User enters an index that is out of range.
 
-- 1b1. BB displays an error message.
+- 1b1. BlockBook displays an error message.
 - Use case ends.
 
 2a. The contact is already marked as a favourite.
 
-- 2a1. BB notifies the user that the contact is already a favourite.
+- 2a1. BlockBook notifies the user that the contact is already a favourite.
 - Use case ends.
 
 2b. The contact is already not a favourite.
 
-- 2b1. BB notifies the user that the contact is already not a favourite.
+- 2b1. BlockBook notifies the user that the contact is already not a favourite.
 - Use case ends.
 
 #### UC04 - Sort Gamer Contacts
@@ -375,7 +375,7 @@ Use case ends.
 **MSS**
 
 1. User requests to sort contacts by one or more attributes.
-2. BB sorts and displays the currently displayed contacts by the specified attributes in priority order.
+2. BlockBook sorts and displays the currently displayed contacts by the specified attributes in priority order.
 
 Use case ends.
 
@@ -383,22 +383,22 @@ Use case ends.
 
 1a. User does not specify any attributes.
 
-- 1a1. BB uses gamertag as the default sort attribute.
+- 1a1. BlockBook uses gamertag as the default sort attribute.
 - Use case resumes from step 2.
 
 1b. User specifies one or more invalid attributes.
 
-- 1b1. BB displays an error message indicating that one or more sort attributes are invalid.
+- 1b1. BlockBook displays an error message indicating that one or more sort attributes are invalid.
 - Use case ends.
 
 1c. User specifies duplicate attributes.
 
-- 1c1. BB displays an error message indicating that duplicate sort attributes are not allowed.
+- 1c1. BlockBook displays an error message indicating that duplicate sort attributes are not allowed.
 - Use case ends.
 
 2a. There are no currently displayed contacts to sort.
 
-- 2a1. BB informs the user that there are no contacts to sort.
+- 2a1. BlockBook informs the user that there are no contacts to sort.
 - Use case ends.
 
 #### UC05 - Edit a Gamer Contact
@@ -406,7 +406,7 @@ Use case ends.
 **MSS**
 
 1. User requests to edit a contact by specifying the contact index and one or more fields to update.
-2. BB updates the contact and displays a success message with the updated contact details.
+2. BlockBook updates the contact and displays a success message with the updated contact details.
 
 Use case ends.
 
@@ -414,31 +414,31 @@ Use case ends.
 
 1a. User enters an invalid index (non-numeric).
 
-- 1a1. BB displays an error message.
+- 1a1. BlockBook displays an error message.
 - 1a2. User re-enters the edit command with corrected input.
 - Use case resumes at step 1.
 
 1b. User enters an index that is out of range.
 
-- 1b1. BB displays an error message.
+- 1b1. BlockBook displays an error message.
 - 1b2. User re-enters the edit command with a valid index.
 - Use case resumes at step 1.
 
 1c. User provides no fields to edit.
 
-- 1c1. BB displays an error message.
+- 1c1. BlockBook displays an error message.
 - 1c2. User re-enters the edit command with at least one field to edit.
 - Use case resumes at step 1.
 
 1d. The new gamertag is already in use by another contact.
 
-- 1d1. BB displays an error message indicating that the gamertag is already in use.
+- 1d1. BlockBook displays an error message indicating that the gamertag is already in use.
 - 1d2. User re-enters the edit command with a different gamertag.
 - Use case resumes at step 1.
 
 1e. One or more entered values are invalid.
 
-- 1e1. BB displays an error message indicating that the input is invalid.
+- 1e1. BlockBook displays an error message indicating that the input is invalid.
 - 1e2. User re-enters the edit command with corrected input.
 - Use case resumes at step 1.
 
@@ -449,12 +449,12 @@ Use case ends.
 
 **MSS**
 1. User requests to delete one or more contacts.
-2. BB deletes the contacts specified and displays a confirmation message.
+2. BlockBook deletes the contacts specified and displays a confirmation message.
 Use case ends.
 
 **Extensions**
 1a. User enters an invalid index.
-- 1a1. BB displays an error message.
+- 1a1. BlockBook displays an error message.
 - Use case ends.
 
 #### UC07 - View a Gamer Contact
@@ -465,7 +465,7 @@ Use case ends.
 **MSS**
 
 1. User requests to view a gamer contact by its index in the current list.
-2. BB displays the contact's full profile details.
+2. BlockBook displays the contact's full profile details.
 
 Use case ends.
 
@@ -473,12 +473,12 @@ Use case ends.
 
 1a. User enters a non-numeric index.
 
-- 1a1. BB displays an error message.
+- 1a1. BlockBook displays an error message.
 - Use case ends.
 
 1b. Index is out of range.
 
-- 1b1. BB displays an error message.
+- 1b1. BlockBook displays an error message.
 - Use case ends.
 
 #### UC08 - Find Gamer Contacts
@@ -486,7 +486,7 @@ Use case ends.
 **MSS**
 
 1. User requests to find gamer contacts using search criteria.
-2. BB shows the matching gamer contacts and a message indicating the number found.
+2. BlockBook shows the matching gamer contacts and a message indicating the number found.
 
 Use case ends.
 
@@ -494,17 +494,17 @@ Use case ends.
 
 1a. User enters empty input or mixes global keywords with prefixed arguments.
 
-- 1a1. BB displays an invalid command format message and the correct usage.
+- 1a1. BlockBook displays an invalid command format message and the correct usage.
 - Use case ends.
 
 1b. User provides an invalid prefixed value (e.g., email/phone/group format is invalid).
 
-- 1b1. BB displays the relevant constraint message.
+- 1b1. BlockBook displays the relevant constraint message.
 - Use case ends.
 
-2a. BB finds no matching gamers.
+2a. BlockBook finds no matching gamers.
 
-- 2a1. BB displays a “no gamers found” message and does not update the current list.
+- 2a1. BlockBook displays a “no gamers found” message and does not update the current list.
 - Use case ends.
 
 #### UC09 - Clear all Gamer Contacts
@@ -513,21 +513,21 @@ Use case ends.
 
 **MSS**
 1. User requests to clear all contacts.
-2. BB prompts the user for confirmation.
+2. BlockBook prompts the user for confirmation.
 3. User confirms.
-4. BB deletes all contacts and displays a success message.
+4. BlockBook deletes all contacts and displays a success message.
 
 **Extensions**
 2a. User does not follow through with confirmation.
 - Use case ends
 3a. User used the wrong confirmation input.
-- 3a1. BB displays an error message and prompts the user for confirmation again.
+- 3a1. BlockBook displays an error message and prompts the user for confirmation again.
 - Use case resumes from step 3.
 
 #### UC10 - Show Help
 **MSS**
 1. User requests to view the help message.
-2. BB displays a help message that includes a summary of all available commands and their usage.
+2. BlockBook displays a help message that includes a summary of all available commands and their usage.
 
 Use case ends.
 
@@ -535,121 +535,121 @@ Use case ends.
 
 **MSS**
 1. User requests to create a group with a group name.
-2. BB creates the group and displays a success message.
+2. BlockBook creates the group and displays a success message.
 
 Use case ends.
 
 **Extensions**
 1a. The group name is invalid.
-- 1a1. BB displays an error message.
+- 1a1. BlockBook displays an error message.
 - Use case ends.
 
 1b. A group with the same name already exists.
-- 1b1. BB displays an error message.
+- 1b1. BlockBook displays an error message.
 - Use case ends.
 
 #### UC12 - Edit a Group
 
 **MSS**
 1. User requests to edit a group by its index and provides a new group name.
-2. BB updates the group name and displays a success message.
+2. BlockBook updates the group name and displays a success message.
 
 Use case ends.
 
 **Extensions**
 1a. User enters an invalid index.
-- 1a1. BB displays an error message.
+- 1a1. BlockBook displays an error message.
 - Use case ends.
 
 1b. The group name is invalid.
-- 1b1. BB displays an error message.
+- 1b1. BlockBook displays an error message.
 - Use case ends.
 
 1c. A group with the same name already exists.
-- 1c1. BB displays an error message.
+- 1c1. BlockBook displays an error message.
 - Use case ends.
 
 #### UC13 - Delete a Group
 
 **MSS**
 1. User requests to delete a group by its index.
-2. BB prompts the user with a confirmation code and repeats the required delete format.
+2. BlockBook prompts the user with a confirmation code and repeats the required delete format.
 3. User confirms by entering the group index and confirmation code.
-4. BB deletes the group and removes it from all associated gamers.
-5. BB displays a success message.
+4. BlockBook deletes the group and removes it from all associated gamers.
+5. BlockBook displays a success message.
 
 Use case ends.
 
 **Extensions**
 1a. User enters an invalid index.
-- 1a1. BB displays an error message.
+- 1a1. BlockBook displays an error message.
 - Use case ends.
 
 2a. User does not follow through with confirmation.
 - Use case ends.
 
 3a. User used the wrong confirmation input.
-- 3a1. BB displays an error message and prompts the user for confirmation again with a new code.
+- 3a1. BlockBook displays an error message and prompts the user for confirmation again with a new code.
 - Use case resumes from step 3.
 
 #### UC14 - Add a Gamer to a Group
 
 **MSS**
 1. User requests to add a gamer to a group by providing the gamer index and group index.
-2. BB adds the gamer to the group and displays a success message.
+2. BlockBook adds the gamer to the group and displays a success message.
 
 Use case ends.
 
 **Extensions**
 1a. User enters an invalid index.
-- 1a1. BB displays an error message.
+- 1a1. BlockBook displays an error message.
 - Use case ends.
 
 1b. The gamer is already in the group.
-- 1b1. BB displays an error message.
+- 1b1. BlockBook displays an error message.
 - Use case ends.
 
 #### UC15 - Remove a Gamer from a Group
 
 **MSS**
 1. User requests to remove a gamer from a group by providing the gamer index and the gamer's group index.
-2. BB removes the gamer from the group and displays a success message.
+2. BlockBook removes the gamer from the group and displays a success message.
 
 Use case ends.
 
 **Extensions**
 1a. User enters an invalid index.
-- 1a1. BB displays an error message.
+- 1a1. BlockBook displays an error message.
 - Use case ends.
 
 #### UC16 - List all Groups
 
 **MSS**
 1. User requests to list all groups.
-2. BB displays the list of groups.
+2. BlockBook displays the list of groups.
 
 Use case ends.
 
 **Extensions**
 1a. The group list is empty.
-- 1a1. BB informs the user that no groups are currently stored.
+- 1a1. BlockBook informs the user that no groups are currently stored.
 - Use case ends.
 
 #### UC17 - View a Group
 
 **MSS**
 1. User requests to view a group by its index.
-2. BB displays the gamers associated with that group.
+2. BlockBook displays the gamers associated with that group.
 
 Use case ends.
 
 **Extensions**
 1a. User enters an invalid index.
-- 1a1. BB displays an error message.
+- 1a1. BlockBook displays an error message.
 - Use case ends.
 
 2a. There are no gamers in the group.
-- 2a1. BB displays a message indicating there are no associated gamers and leaves the current list unchanged.
+- 2a1. BlockBook displays a message indicating there are no associated gamers and leaves the current list unchanged.
 - Use case ends.
 
 ### Non-Functional Requirements

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -255,11 +255,13 @@ Format 1: `(f)ind KEYWORD`
 * The search is case-insensitive and uses partial (substring) matching.
 * If you include spaces in `KEYWORD`, the full phrase is matched as a single substring.
 * Each `find` replaces the current filter (it does not stack with previous `find` results).
+* A match is found if the keyword appears in any attribute (except favourite).
 
 Format 2: `(f)ind [(g)amertag/GAMERTAG] [(n)ame/NAME] [(p)hone/PHONE] [(e)mail/EMAIL] [(gr)oup/GROUP] [(s)erver/SERVER] [(fav)avourite/] [(c)ountry/COUNTRY] [(r)egion/REGION] [note/NOTE]`
 
 * Prefixes can be stacked in one command.
 * Prefixes use the same short-form notation, e.g. `(n)ame/` means `name/` or `n/`.
+* When multiple prefixes are provided, a gamer must match all specified prefixes (AND).
 * Each `find` replaces the current filter (it does not stack with previous `find` results).
 
 Examples:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -6,7 +6,7 @@ pageNav: 3
 
 # BlockBook User Guide
 
-BlockBook is a **desktop app for managing contacts, optimized for use via a  Line Interface** (CLI) while still having the benefits of a Graphical User Interface (GUI). If you can type fast, BlockBook can get your contact management tasks done faster than traditional GUI apps.
+BlockBook is a **desktop app for managing Minecraft gamer contacts, optimized for use via a Command Line Interface** (CLI) while still having the benefits of a Graphical User Interface (GUI). If you can type fast, BlockBook can get your contact management tasks done faster than traditional GUI apps.
 
 BlockBook makes it easy to manage the contacts of other gamers you meet on servers, allowing you to manage contacts through not just names, but other gaming attributes too.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -411,7 +411,9 @@ Format: `groupedit BLOCKBOOK_GROUP_INDEX NEW_GROUP_NAME` or `ge BLOCKBOOK_GROUP_
 
 * The `BLOCKBOOK_GROUP_INDEX` refers to the index shown in the group list.
 * The new group name follows the same constraints as group creation.
-* Renaming is case-insensitive for uniqueness (e.g., renaming `Raid Team` to `raid team` is allowed).
+* Group names are unique case-insensitively across different groups, so only one instance of a group name can exist
+* (e.g. if a group named `Raid Team` exists, another group cannot be named `raid team`).
+* Changing the letter casing of the same group name (e.g., `Raid Team` → `raid team`) is allowed which is an exception to the rule above.
 
 Examples:
 * `groupedit 1 iloveAlex`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -6,7 +6,7 @@ pageNav: 3
 
 # BlockBook User Guide
 
-BlockBook is a **desktop app for managing Minecraft gamer contacts, optimized for use via a Command Line Interface** (CLI) while still having the benefits of a Graphical User Interface (GUI). If you can type fast, BlockBook can get your contact management tasks done faster than traditional GUI apps.
+BlockBook is a **desktop app built for Minecraft players to manage Minecraft gamer contacts, optimized for use via a Command Line Interface** (CLI) while still having the benefits of a Graphical User Interface (GUI). If you can type fast, BlockBook can get your contact management tasks done faster than traditional GUI apps.
 
 BlockBook makes it easy to manage the contacts of other gamers you meet on servers, allowing you to manage contacts through not just names, but other gaming attributes too.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -263,6 +263,7 @@ Format 2: `(f)ind [(g)amertag/GAMERTAG] [(n)ame/NAME] [(p)hone/PHONE] [(e)mail/E
 * Prefixes use the same short-form notation, e.g. `(n)ame/` means `name/` or `n/`.
 * When multiple prefixes are provided, a gamer must match all specified prefixes (AND).
 * Each `find` replaces the current filter (it does not stack with previous `find` results).
+* `region/` must use a full region value (e.g., `ASIA`), not a partial substring. This is case-insensitive.
 
 Examples:
 * `find steve`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -254,11 +254,13 @@ Format 1: `(f)ind KEYWORD`
 
 * The search is case-insensitive and uses partial (substring) matching.
 * If you include spaces in `KEYWORD`, the full phrase is matched as a single substring.
+* Each `find` replaces the current filter (it does not stack with previous `find` results).
 
 Format 2: `(f)ind [(g)amertag/GAMERTAG] [(n)ame/NAME] [(p)hone/PHONE] [(e)mail/EMAIL] [(gr)oup/GROUP] [(s)erver/SERVER] [(fav)avourite/] [(c)ountry/COUNTRY] [(r)egion/REGION] [note/NOTE]`
 
 * Prefixes can be stacked in one command.
 * Prefixes use the same short-form notation, e.g. `(n)ame/` means `name/` or `n/`.
+* Each `find` replaces the current filter (it does not stack with previous `find` results).
 
 Examples:
 * `find steve`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -537,23 +537,23 @@ Furthermore, certain edits can cause BlockBook to behave in unexpected ways (e.g
 
 ## Command summary
 
-| Action           | Format, Examples                                                                                                           |
-|------------------|----------------------------------------------------------------------------------------------------------------------------|
-| **Add**          | `(a)dd (g)amertag/GAMERTAG [(n)ame/NAME]...` <br> e.g., `add g/JamieH n/James Ho`                                          |
-| **Clear**        | `clear [CONFIRMATION_CODE]`                                                                                                |
-| **Delete**       | `(d)elete GAMER_INDEX [GAMER_INDEX]...`<br> e.g., `delete 3`, `delete 2 5`                                                 |
-| **Edit**         | `(e)dit GAMER_INDEX [(g)amertag/GAMERTAG] [(n)ame/NAME]...`<br> e.g., `edit 2 n/James Lee`                                 |
-| **Find**         | `(f)ind KEYWORD`<br> e.g., `find James`<br> `find [(n)ame/NAME] [(g)amertag/GAMERTAG]...`<br> e.g., `find n/Steve g/Block` |
-| **View**         | `(v)iew GAMER_INDEX` <br> e.g., `view 2`                                                                                   |
-| **List**         | `(l)ist`                                                                                                                   |
-| **Favourite**    | `(fav)ourite GAMER_INDEX`<br> e.g., `favourite 1`                                                                          |
-| **Unfavourite**  | `(unfav)ourite GAMER_INDEX`<br> e.g., `unfavourite 1`                                                                      |
-| **Sort**         | `(s)ort [(g)amertag/] [(n)ame/]...`<br> e.g., `sort`, `sort n/`, `sort p/ g/`                                              |
-| **Help**         | `help`, `?`                                                                                                                |
-| **Group Create** | `groupcreate GROUP`, `gc GROUP`<br> e.g., `gc Raid Team`                                                                   |
-| **Group Edit**   | `groupedit BLOCKBOOK_GROUP_INDEX NEW_GROUP_NAME`, `ge ...`<br> e.g., `ge 1 Arena Team`                                     |
-| **Group Delete** | `groupnuke BLOCKBOOK_GROUP_INDEX [CONFIRMATION_CODE]`, `gn ...`<br> e.g., `gn 1 abc123`                                                       |
-| **Group Add**    | `groupadd GAMER_INDEX BLOCKBOOK_GROUP_INDEX`, `ga ...`<br> e.g., `ga 2 1`                                                  |
-| **Group Remove** | `groupremove GAMER_INDEX GAMER_GROUP_INDEX`, `gr ...`<br> e.g., `gr 2 1`                                                   |
-| **Group List**   | `grouplist`, `gl`                                                                                                          |
-| **Group View**   | `groupview BLOCKBOOK_GROUP_INDEX`, `gv ...`<br> e.g., `gv 1`                                                               |
+| Action           | Format, Examples                                                                                                                                                                                                                                               |
+|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Add**          | `(a)dd (g)amertag/GAMERTAG [(n)ame/NAME] [(p)hone/PHONE] [(e)mail/EMAIL] [(s)erver/SERVER] [(c)ountry/COUNTRY] [(r)egion/REGION] [note/NOTE]`<br> e.g., `add g/JamieH n/James Ho`                                                                              |
+| **Edit**         | `(e)dit GAMER_INDEX [(g)amertag/GAMERTAG] [(n)ame/NAME] [(p)hone/PHONE] [(e)mail/EMAIL] [(s)erver/SERVER] [(c)ountry/COUNTRY] [(r)egion/REGION] [note/NOTE]`<br> e.g., `edit 2 n/James Lee`                                                                    |
+| **Find**         | `(f)ind KEYWORD`<br> e.g., `find James`<br> `(f)ind [(g)amertag/GAMERTAG] [(n)ame/NAME] [(p)hone/PHONE] [(e)mail/EMAIL] [(gr)oup/GROUP] [(s)erver/SERVER] [(fav)avourite/] [(c)ountry/COUNTRY] [(r)egion/REGION] [note/NOTE]`<br> e.g., `find n/Steve g/Block` |
+| **View**         | `(v)iew GAMER_INDEX` <br> e.g., `view 2`                                                                                                                                                                                                                       |
+| **List**         | `(l)ist`<br> e.g., `list`                                                                                                                                                                                                                                      |
+| **Favourite**    | `(fav)ourite GAMER_INDEX`<br> e.g., `favourite 1`                                                                                                                                                                                                              |
+| **Unfavourite**  | `(unfav)ourite GAMER_INDEX`<br> e.g., `unfavourite 1`                                                                                                                                                                                                          |
+| **Sort**         | `(s)ort [(g)amertag/] [(n)ame/] [(p)hone/] [(e)mail/] [(gr)oup/] [(s)erver/] [(fav)ourite/] [(c)ountry/] [(r)egion/] [note/]`<br> e.g., `sort`, `sort n/`, `sort p/ g/`                                                                                        |
+| **Help**         | `help`, `?`<br> e.g., `help`                                                                                                                                                                                                                                   |
+| **Group Create** | `groupcreate GROUP`, `gc GROUP`<br> e.g., `gc Raid Team`                                                                                                                                                                                                       |
+| **Group Edit**   | `groupedit BLOCKBOOK_GROUP_INDEX NEW_GROUP_NAME`, `ge BLOCKBOOK_GROUP_INDEX NEW_GROUP_NAME`<br> e.g., `ge 1 Arena Team`                                                                                                                                        |
+| **Group Add**    | `groupadd GAMER_INDEX BLOCKBOOK_GROUP_INDEX`, `ga GAMER_INDEX BLOCKBOOK_GROUP_INDEX`<br> e.g., `ga 2 1`                                                                                                                                                        |
+| **Group List**   | `grouplist`, `gl`<br> e.g., `grouplist`                                                                                                                                                                                                                        |
+| **Group View**   | `groupview BLOCKBOOK_GROUP_INDEX`, `gv BLOCKBOOK_GROUP_INDEX`<br> e.g., `gv 1`                                                                                                                                                                                 |
+| **Group Delete** | `groupnuke BLOCKBOOK_GROUP_INDEX [CONFIRMATION_CODE]`, `gn BLOCKBOOK_GROUP_INDEX [CONFIRMATION_CODE]`<br> e.g., `gn 1 abc123`                                                                                                                                  |
+| **Group Remove** | `groupremove GAMER_INDEX GAMER_GROUP_INDEX`, `gr GAMER_INDEX GAMER_GROUP_INDEX`<br> e.g., `gr 2 1`                                                                                                                                                             |
+| **Delete**       | `(d)elete GAMER_INDEX [GAMER_INDEX]...`<br> e.g., `delete 3`, `delete 2 5`                                                                                                                                                                                     |
+| **Clear**        | `clear [CONFIRMATION_CODE]`<br> e.g., `clear`, `clear 2v8wua`                                                                                                                                                                                                  |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -422,13 +422,13 @@ Deletes a group from BlockBook and removes that group from all gamers associated
 Format: `groupnuke BLOCKBOOK_GROUP_INDEX [CONFIRMATION_CODE]` or `gn BLOCKBOOK_GROUP_INDEX [CONFIRMATION_CODE]`
 
 * This is a **destructive** command and requires confirmation.
-* BB will show a warning message with a confirmation code and the affected gamertags.
+* BlockBook will show a warning message with a confirmation code and the affected gamertags.
 * Re-run the command with the confirmation code appended to proceed.
-* If you enter the wrong code, BB will show a new confirmation code.
+* If you enter the wrong code, BlockBook will show a new confirmation code.
 
 Example:
 * `groupnuke 1`
-  BB will prompt you with a confirmation code.
+  BlockBook will prompt you with a confirmation code.
 
 ![result for 'groupnuke 1'](images/groupNukeResult1.png)
 * `groupnuke 1 j5n0w3`
@@ -470,7 +470,7 @@ Lists all groups stored in BlockBook.
 
 Format: `grouplist` or `gl`
 
-* If there are no groups, BB will indicate that no groups were found.
+* If there are no groups, BlockBook will indicate that no groups were found.
 
 Example:
 * `grouplist`
@@ -485,7 +485,7 @@ Format: `groupview BLOCKBOOK_GROUP_INDEX` or `gv BLOCKBOOK_GROUP_INDEX`
 
 * `BLOCKBOOK_GROUP_INDEX` refers to the index shown in the group list.
 * The displayed gamer list is filtered to show only members of the selected group.
-* If no gamers belong to the group, BB will show a message and keep the current list unchanged.
+* If no gamers belong to the group, BlockBook will show a message and keep the current list unchanged.
 
 Example:
 * `groupview 1` shows all gamers in the 1st group.


### PR DESCRIPTION
Closes #420 . Updates "BB" to "BlockBook"
Closes #439 . Updates `groupedit` command to mention about the renaming exception to the case insensitive rule
Closes #404 . Updates command summary with full usages for all commands
Closes #428 . Moves destructive commands to the end
Closes #375 . Updates target audience to be "**Minecraft** players and use case to manage **Minecraft** gamer contacts"
Closes #395  . Updates "Line Interface" to "Command Line Interface".
Closes #415 . Updates `find` command to mention it does not stack
Closes #403 . Updates `find` command to mention how it works with global and prefix based searches
Closes #429 . Updates `find` command to mention that region values must use the full region values in region prefix search