### PR TITLE
[PE-D][Tester C] Country field validation incorrectly allows backslash (\) character

### DIFF
--- a/src/main/java/seedu/blockbook/model/gamer/Country.java
+++ b/src/main/java/seedu/blockbook/model/gamer/Country.java
@@ -14,7 +14,7 @@ public class Country {
             "Country should only contain letters, spaces, and hyphens, "
                     + "and be at most 50 characters.";
 
-    public static final String VALIDATION_REGEX = "^[a-zA-Z \\\\-]{1,50}$";
+    public static final String VALIDATION_REGEX = "^[a-zA-Z -]{1,50}$";
     public final String fullCountry;
 
     /**

--- a/src/test/java/seedu/blockbook/model/gamer/CountryTest.java
+++ b/src/test/java/seedu/blockbook/model/gamer/CountryTest.java
@@ -27,6 +27,7 @@ public class CountryTest {
         assertFalse(Country.isValidCountry("United_States"));
         assertFalse(Country.isValidCountry("Singapore!"));
         assertFalse(Country.isValidCountry("A".repeat(51)));
+        assertFalse(Country.isValidCountry("Sin/gapore"));
 
         assertTrue(Country.isValidCountry("Singapore"));
         assertTrue(Country.isValidCountry("New Zealand"));


### PR DESCRIPTION
Change from `"^[a-zA-Z \\\\-]{1,50}$"` -> `"^[a-zA-Z -]{1,50}$"`
Closes #410
1 line of functional code changed