### PR TITLE
Update Email Validation for `local-part` and `domain`

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -106,7 +106,7 @@ Examples:
 - `gamertag/`: letters, numbers, underscores only, max 50 characters.
 - `name/`: letters, spaces, hyphens, apostrophes only, max 50 characters.
 - `phone/`: optional leading `+`, digits/spaces/hyphens, at least 3 digits, at most 15 digits, max 30 characters.
-- `email/`: must be a valid email in the format `local-part@domain`.
+- `email/`: must be a valid email in the format `local-part@domain`, where the domain contains at least **two labels** separated by periods (e.g. `example.com`).
 - `server/`: letters, numbers, `.`, `-`, `:`, max 50 characters.
 - `country/`: letters, spaces, hyphens only, max 50 characters.
 - `region/`: accepts `NA`, `SA`, `EU`, `AFRICA`, `ASIA`, `OCEANIA` or `ME`.
@@ -176,7 +176,7 @@ Examples:
 - `gamertag/`: letters, numbers, underscores only, max 50 characters.
 - `name/`: letters, spaces, hyphens, apostrophes only, max 50 characters.
 - `phone/`: optional leading `+`, digits/spaces/hyphens, at least 3 digits, at most 15 digits, max 30 characters.
-- `email/`: must be a valid email in the format `local-part@domain`.
+- `email/`: must be a valid email in the format `local-part@domain`, where the domain contains at least **two labels** separated by periods (e.g. `example.com`).
 - `server/`: letters, numbers, `.`, `-`, `:`, max 50 characters.
 - `country/`: letters, spaces, hyphens only, max 50 characters.
 - `region/`: accepts `NA`, `SA`, `EU`, `AFRICA`, `ASIA`, `OCEANIA` or `ME`.

--- a/src/main/java/seedu/blockbook/model/gamer/Email.java
+++ b/src/main/java/seedu/blockbook/model/gamer/Email.java
@@ -18,8 +18,8 @@ public class Email {
             + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
             + "the parentheses, (" + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special "
             + "characters.\n"
-            + "2. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
-            + "separated by periods.\n"
+            + "2. This is followed by a '@' and then a domain name. The domain name must contain at least two domain "
+            + "labels separated by periods.\n"
             + "The domain name must:\n"
             + "    - end with a domain label at least 2 characters long\n"
             + "    - have each domain label start and end with alphanumeric characters\n"
@@ -27,12 +27,12 @@ public class Email {
 
     // alphanumeric and special characters
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
-    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
-            + ALPHANUMERIC_NO_UNDERSCORE + ")*";
+    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "(?:["
+            + SPECIAL_CHARACTERS + ALPHANUMERIC_NO_UNDERSCORE + "]*" + ALPHANUMERIC_NO_UNDERSCORE + ")?";
     private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
             + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
-    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
+    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)+" + DOMAIN_LAST_PART_REGEX;
 
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
     public final String fullEmail;
@@ -88,4 +88,3 @@ public class Email {
     }
 
 }
-

--- a/src/test/java/seedu/blockbook/model/gamer/EmailTest.java
+++ b/src/test/java/seedu/blockbook/model/gamer/EmailTest.java
@@ -23,18 +23,122 @@ public class EmailTest {
     public void isValidEmail() {
         assertThrows(NullPointerException.class, () -> Email.isValidEmail(null));
 
+        // invalid overall structure: missing or malformed '@'
+        assertFalse(Email.isValidEmail("aliceexample.com"));
+        assertFalse(Email.isValidEmail("alice.example.com"));
+        assertFalse(Email.isValidEmail("alice@@example.com"));
+        assertFalse(Email.isValidEmail("alice@bob@example.com"));
+        assertFalse(Email.isValidEmail("alice@"));
         assertFalse(Email.isValidEmail("@example.com"));
+        assertFalse(Email.isValidEmail("@"));
+        assertFalse(Email.isValidEmail(""));
+
+        // invalid structure: spaces around '@'
+        assertFalse(Email.isValidEmail("alice @example.com"));
+        assertFalse(Email.isValidEmail("alice@ example.com"));
+        assertFalse(Email.isValidEmail("alice @ example.com"));
+
+        // invalid structure: unsupported chars adjacent to '@'
+        assertFalse(Email.isValidEmail("alice,@example.com"));
+        assertFalse(Email.isValidEmail("alice;@example.com"));
+        assertFalse(Email.isValidEmail("alice@,example.com"));
+        assertFalse(Email.isValidEmail("alice@;example.com"));
+
+        // invalid local-part: missing local-part entirely
+        assertFalse(Email.isValidEmail("@example.com"));
+
+        // invalid local-part: starts with special character
+        assertFalse(Email.isValidEmail(".alice@example.com"));
+        assertFalse(Email.isValidEmail("+alice@example.com"));
+        assertFalse(Email.isValidEmail("_alice@example.com"));
+        assertFalse(Email.isValidEmail("-alice@example.com"));
+
+        // invalid local-part: ends with special character
+        assertFalse(Email.isValidEmail("alice.@example.com"));
+        assertFalse(Email.isValidEmail("alice+@example.com"));
+        assertFalse(Email.isValidEmail("alice_@example.com"));
+        assertFalse(Email.isValidEmail("alice-@example.com"));
+
+        // invalid local-part: contains unsupported characters
+        assertFalse(Email.isValidEmail("ali!ce@example.com"));
+        assertFalse(Email.isValidEmail("ali#ce@example.com"));
+        assertFalse(Email.isValidEmail("ali ce@example.com"));
+        assertFalse(Email.isValidEmail("alice,@example.com"));
+        assertFalse(Email.isValidEmail("alice;bob@example.com"));
+        assertFalse(Email.isValidEmail("alice:bob@example.com"));
+        assertFalse(Email.isValidEmail("alice/bob@example.com"));
+        assertFalse(Email.isValidEmail("alice(bob)@example.com"));
+        assertFalse(Email.isValidEmail("\"alice\"@example.com"));
+
+        // valid local-part: alphanumeric only
+        assertTrue(Email.isValidEmail("alice@example.com"));
+        assertTrue(Email.isValidEmail("a1b2c3@example.com"));
+        assertTrue(Email.isValidEmail("z@example.com"));
+        assertTrue(Email.isValidEmail("A123456789@example.com"));
+
+        // valid local-part: one allowed special character internally
+        assertTrue(Email.isValidEmail("alice.bob@example.com"));
+        assertTrue(Email.isValidEmail("alice+bob@example.com"));
+        assertTrue(Email.isValidEmail("alice_bob@example.com"));
+        assertTrue(Email.isValidEmail("alice-bob@example.com"));
+        assertTrue(Email.isValidEmail("a.b@example.com"));
+        assertTrue(Email.isValidEmail("a+b@example.com"));
+        assertTrue(Email.isValidEmail("a_b@example.com"));
+        assertTrue(Email.isValidEmail("a-b@example.com"));
+
+        // valid local-part: repeated same special character internally
+        assertTrue(Email.isValidEmail("alice..bob@example.com"));
+        assertTrue(Email.isValidEmail("alice++bob@example.com"));
+        assertTrue(Email.isValidEmail("alice__bob@example.com"));
+        assertTrue(Email.isValidEmail("alice--bob@example.com"));
+
+        // valid local-part: mixed allowed special characters internally
+        assertTrue(Email.isValidEmail("alice.bob+charlie@example.com"));
+        assertTrue(Email.isValidEmail("alice_bob-charlie@example.com"));
+        assertTrue(Email.isValidEmail("a+b_c-d.e@example.com"));
+        assertTrue(Email.isValidEmail("john_+_-.doe@example.com"));
+        assertTrue(Email.isValidEmail("a._+-b@example.com"));
+        assertTrue(Email.isValidEmail("abc+_.-def@example.com"));
+        assertTrue(Email.isValidEmail("a..b__c--d++e@example.com"));
+
+        // valid local-part: long but still structurally valid
+        assertTrue(Email.isValidEmail("abcdefghijklmnopqrstuvwxyz@example.com"));
+        assertTrue(Email.isValidEmail("abc123.def456+ghi789_jkl-mno@example.com"));
+
+        // domain must be made up of labels separated by periods
+        assertFalse(Email.isValidEmail("alice@example"));
         assertFalse(Email.isValidEmail("alice@"));
         assertFalse(Email.isValidEmail("alice@.com"));
-        assertFalse(Email.isValidEmail("alice@example.c"));
-        assertFalse(Email.isValidEmail(".alice@example.com"));
-        assertFalse(Email.isValidEmail("alice.@example.com"));
         assertFalse(Email.isValidEmail("alice@example..com"));
 
-        assertTrue(Email.isValidEmail("alice@example"));
+        // domain must end with a label at least 2 characters long
+        assertFalse(Email.isValidEmail("alice@example.c"));
+        assertFalse(Email.isValidEmail("alice@me.a"));
+
+        // each domain label must start and end with alphanumeric characters
+        assertFalse(Email.isValidEmail("alice@-example.com"));
+        assertFalse(Email.isValidEmail("alice@example-.com"));
+        assertFalse(Email.isValidEmail("alice@..example.com"));
+        assertFalse(Email.isValidEmail("alice@sub.-example.com"));
+        assertFalse(Email.isValidEmail("alice@sub.example-.com"));
+
+        // each domain label may contain only alphanumeric characters and internal hyphens
+        assertFalse(Email.isValidEmail("alice@exam_ple.com"));
+        assertFalse(Email.isValidEmail("alice@example!.com"));
+        assertFalse(Email.isValidEmail("alice@exa%mple.com"));
+
+        // valid emails
         assertTrue(Email.isValidEmail("alice@example.com"));
         assertTrue(Email.isValidEmail("alice.bob+tag@example-domain.com"));
         assertTrue(Email.isValidEmail("a1_b@example.co"));
+        assertTrue(Email.isValidEmail("me@nus.edu.sg"));
+        assertTrue(Email.isValidEmail("john_doe@sub-domain.example.org"));
+        assertTrue(Email.isValidEmail("a@a.cd"));
+        assertTrue(Email.isValidEmail("user123@alpha-beta.gamma"));
+        assertTrue(Email.isValidEmail("first.last@one-two.three-four.com"));
+        assertTrue(Email.isValidEmail("x_y.z+q@a-b.cdef"));
+        assertTrue(Email.isValidEmail("name@abc-def.gh"));
+        assertTrue(Email.isValidEmail("john_+_-.doe@hotmail.com"));
     }
 
     @Test


### PR DESCRIPTION
**Summary**
Align email validation with the documented rules by rejecting single-label domains and allowing documented internal local-part special characters.

**Changes**
- Require email domains to contain at least two labels separated by periods, so values like `eve@me` are rejected.
- Allow internal runs of `+`,` _`, `.`, and `-` in the local-part as long as it still starts and ends with an alphanumeric character.
- Clarify the email constraint message to explicitly state the domain must contain **at least two domain labels** separated by periods to ensure clarity.
- Expand `EmailTest` coverage for local-part edge cases, malformed `@` structure, and domain-label rules.

Closes #398 
Closes #436 

5 lines of functional code edited.